### PR TITLE
Define exception type

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,3 +1,4 @@
+use crate::exception::Exception;
 use bit_field::BitField;
 use std::ops::Range;
 
@@ -178,8 +179,8 @@ impl JType {
     }
 }
 
-pub fn decode(instruction: u32) -> Instruction {
-    match instruction.get_bits(OPCODE_RANGE) {
+pub fn decode(instruction: u32) -> Result<Instruction, Exception> {
+    let decoded = match instruction.get_bits(OPCODE_RANGE) {
         // R-Type
         0b0110011 => match instruction.get_bits(FUNCT3_RANGE) {
             0b000 => match instruction.get_bits(FUNCT7_RANGE) {
@@ -198,7 +199,7 @@ pub fn decode(instruction: u32) -> Instruction {
             },
             0b110 => Instruction::Or(RType::new(instruction)),
             0b111 => Instruction::And(RType::new(instruction)),
-            _ => panic!("Invalid instruction"),
+            _ => return Err(Exception::IllegalInstruction),
         },
 
         // I Type
@@ -212,11 +213,11 @@ pub fn decode(instruction: u32) -> Instruction {
             0b101 => match instruction.get_bits(FUNCT7_RANGE) {
                 0b0000000 => Instruction::Srli(IType::new(instruction)),
                 0b0100000 => Instruction::Srai(IType::new(instruction)),
-                _ => panic!("Invalid instruction"),
+                _ => return Err(Exception::IllegalInstruction),
             },
             0b110 => Instruction::Ori(IType::new(instruction)),
             0b111 => Instruction::Andi(IType::new(instruction)),
-            _ => panic!("Invalid instruction"),
+            _ => return Err(Exception::IllegalInstruction),
         },
         0b0000011 => match instruction.get_bits(FUNCT3_RANGE) {
             0b000 => Instruction::Lb(IType::new(instruction)),
@@ -224,7 +225,7 @@ pub fn decode(instruction: u32) -> Instruction {
             0b010 => Instruction::Lw(IType::new(instruction)),
             0b100 => Instruction::Lbu(IType::new(instruction)),
             0b101 => Instruction::Lhu(IType::new(instruction)),
-            _ => panic!("Invalid instruction"),
+            _ => return Err(Exception::IllegalInstruction),
         },
         0b1110011 => match instruction.get_bits(FUNCT3_RANGE) {
             0b001 => Instruction::Csrrw(IType::new(instruction)),
@@ -233,7 +234,7 @@ pub fn decode(instruction: u32) -> Instruction {
             0b101 => Instruction::Csrrwi(IType::new(instruction)),
             0b110 => Instruction::Csrrsi(IType::new(instruction)),
             0b111 => Instruction::Csrrci(IType::new(instruction)),
-            _ => panic!("Invalid instruction"),
+            _ => return Err(Exception::IllegalInstruction),
         },
 
         // S-Type
@@ -241,7 +242,7 @@ pub fn decode(instruction: u32) -> Instruction {
             0b000 => Instruction::Sb(SType::new(instruction)),
             0b001 => Instruction::Sh(SType::new(instruction)),
             0b010 => Instruction::Sw(SType::new(instruction)),
-            _ => panic!("Invalid instruction"),
+            _ => return Err(Exception::IllegalInstruction),
         },
 
         // B-Type
@@ -252,7 +253,7 @@ pub fn decode(instruction: u32) -> Instruction {
             0b101 => Instruction::Bge(BType::new(instruction)),
             0b110 => Instruction::Bltu(BType::new(instruction)),
             0b111 => Instruction::Bgeu(BType::new(instruction)),
-            _ => panic!("Invalid instruction"),
+            _ => return Err(Exception::IllegalInstruction),
         },
 
         // J-Type
@@ -261,8 +262,9 @@ pub fn decode(instruction: u32) -> Instruction {
         // U-Type
         0b0110111 => Instruction::Lui(UType::new(instruction)),
         0b0010111 => Instruction::Auipc(UType::new(instruction)),
-        _ => panic!("Invalid instruction"),
-    }
+        _ => return Err(Exception::IllegalInstruction),
+    };
+    Ok(decoded)
 }
 
 #[cfg(test)]
@@ -270,7 +272,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn decode_rv32i_r() {
+    fn decode_rv32i_r() -> Result<(), Exception> {
         // add x1, x9, x5
         assert_eq!(
             Instruction::Add(RType {
@@ -278,7 +280,7 @@ mod tests {
                 rs1: 9,
                 rs2: 5,
             }),
-            decode(0b0000000_00101_01001_000_00001_0110011)
+            decode(0b0000000_00101_01001_000_00001_0110011)?
         );
 
         // sub x2, x6, x21
@@ -288,7 +290,7 @@ mod tests {
                 rs1: 6,
                 rs2: 21,
             }),
-            decode(0b0100000_10101_00110_000_00010_0110011)
+            decode(0b0100000_10101_00110_000_00010_0110011)?
         );
 
         // sll x3, x4, x24
@@ -298,7 +300,7 @@ mod tests {
                 rs1: 4,
                 rs2: 24,
             }),
-            decode(0b0000000_11000_00100_001_00011_0110011)
+            decode(0b0000000_11000_00100_001_00011_0110011)?
         );
 
         // slt x4, x19, x31
@@ -308,7 +310,7 @@ mod tests {
                 rs1: 19,
                 rs2: 31,
             }),
-            decode(0b0000000_11111_10011_010_00100_0110011)
+            decode(0b0000000_11111_10011_010_00100_0110011)?
         );
 
         // sltu x5, x12, x11
@@ -318,7 +320,7 @@ mod tests {
                 rs1: 12,
                 rs2: 11,
             }),
-            decode(0b0000000_01011_01100_011_00101_0110011)
+            decode(0b0000000_01011_01100_011_00101_0110011)?
         );
 
         // xor x6, x17, x25
@@ -328,7 +330,7 @@ mod tests {
                 rs1: 17,
                 rs2: 25,
             }),
-            decode(0b0000000_11001_10001_100_00110_0110011)
+            decode(0b0000000_11001_10001_100_00110_0110011)?
         );
 
         // srl x7, x27, x15
@@ -338,7 +340,7 @@ mod tests {
                 rs1: 27,
                 rs2: 15,
             }),
-            decode(0b0000000_01111_11011_101_00111_0110011)
+            decode(0b0000000_01111_11011_101_00111_0110011)?
         );
 
         // sra x8, x13, x28
@@ -348,7 +350,7 @@ mod tests {
                 rs1: 13,
                 rs2: 28,
             }),
-            decode(0b0100000_11100_01101_101_01000_0110011)
+            decode(0b0100000_11100_01101_101_01000_0110011)?
         );
 
         // or x9, x30, x25
@@ -358,7 +360,7 @@ mod tests {
                 rs1: 30,
                 rs2: 25,
             }),
-            decode(0b0000000_11001_11110_110_01001_0110011)
+            decode(0b0000000_11001_11110_110_01001_0110011)?
         );
 
         // and x10, x17, x0
@@ -368,12 +370,13 @@ mod tests {
                 rs1: 17,
                 rs2: 0,
             }),
-            decode(0b0000000_00000_10001_111_01010_0110011)
+            decode(0b0000000_00000_10001_111_01010_0110011)?
         );
+        Ok(())
     }
 
     #[test]
-    fn decode_rv32i_i() {
+    fn decode_rv32i_i() -> Result<(), Exception> {
         // jalr x1, x9, 64
         assert_eq!(
             Instruction::Jalr(IType {
@@ -381,7 +384,7 @@ mod tests {
                 rs1: 9,
                 imm: 64,
             }),
-            decode(0b0000010_00000_01001_000_00001_1100111)
+            decode(0b0000010_00000_01001_000_00001_1100111)?
         );
 
         // addi x1, x9, 64
@@ -391,7 +394,7 @@ mod tests {
                 rs1: 9,
                 imm: 64,
             }),
-            decode(0b0000010_00000_01001_000_00001_0010011)
+            decode(0b0000010_00000_01001_000_00001_0010011)?
         );
 
         // slli x2, x6, 17
@@ -401,7 +404,7 @@ mod tests {
                 rs1: 6,
                 imm: 17,
             }),
-            decode(0b0000000_10001_00110_001_00010_0010011)
+            decode(0b0000000_10001_00110_001_00010_0010011)?
         );
 
         // slti x3, x4, 16
@@ -411,7 +414,7 @@ mod tests {
                 rs1: 4,
                 imm: 16,
             }),
-            decode(0b0000000_10000_00100_010_00011_0010011)
+            decode(0b0000000_10000_00100_010_00011_0010011)?
         );
 
         // sltiu x4, x19, 8
@@ -421,7 +424,7 @@ mod tests {
                 rs1: 19,
                 imm: 8,
             }),
-            decode(0b0000000_01000_10011_011_00100_0010011)
+            decode(0b0000000_01000_10011_011_00100_0010011)?
         );
 
         // xori x5, x12, 4
@@ -431,7 +434,7 @@ mod tests {
                 rs1: 12,
                 imm: 4,
             }),
-            decode(0b0000000_00100_01100_100_00101_0010011)
+            decode(0b0000000_00100_01100_100_00101_0010011)?
         );
 
         // srli x6, x17, 5
@@ -441,7 +444,7 @@ mod tests {
                 rs1: 17,
                 imm: 5,
             }),
-            decode(0b0000000_00101_10001_101_00110_0010011)
+            decode(0b0000000_00101_10001_101_00110_0010011)?
         );
 
         // srai x7, x27, 1024
@@ -451,7 +454,7 @@ mod tests {
                 rs1: 27,
                 imm: 1024,
             }),
-            decode(0b0100000_00000_11011_101_00111_0010011)
+            decode(0b0100000_00000_11011_101_00111_0010011)?
         );
 
         // ori x8, x13, 2
@@ -461,7 +464,7 @@ mod tests {
                 rs1: 13,
                 imm: 2,
             }),
-            decode(0b0000000_00010_01101_110_01000_0010011)
+            decode(0b0000000_00010_01101_110_01000_0010011)?
         );
 
         // andi x9, x30, 1
@@ -471,7 +474,7 @@ mod tests {
                 rs1: 30,
                 imm: 1,
             }),
-            decode(0b0000000_00001_11110_111_01001_0010011)
+            decode(0b0000000_00001_11110_111_01001_0010011)?
         );
 
         // lb x9, x30, 2
@@ -481,7 +484,7 @@ mod tests {
                 rs1: 30,
                 imm: 2,
             }),
-            decode(0b0000000_00010_11110_000_01001_0000011)
+            decode(0b0000000_00010_11110_000_01001_0000011)?
         );
 
         // lh x9, x30, 1
@@ -491,7 +494,7 @@ mod tests {
                 rs1: 30,
                 imm: 1,
             }),
-            decode(0b0000000_00001_11110_001_01001_0000011)
+            decode(0b0000000_00001_11110_001_01001_0000011)?
         );
 
         // lw x9, x30, 2048
@@ -501,7 +504,7 @@ mod tests {
                 rs1: 30,
                 imm: 2048,
             }),
-            decode(0b1000000_00000_11110_010_01001_0000011)
+            decode(0b1000000_00000_11110_010_01001_0000011)?
         );
 
         // lbu x9, x30, 1
@@ -511,7 +514,7 @@ mod tests {
                 rs1: 30,
                 imm: 1,
             }),
-            decode(0b0000000_00001_11110_100_01001_0000011)
+            decode(0b0000000_00001_11110_100_01001_0000011)?
         );
 
         // lhu x9, x30, 1
@@ -521,7 +524,7 @@ mod tests {
                 rs1: 30,
                 imm: 1,
             }),
-            decode(0b0000000_00001_11110_101_01001_0000011)
+            decode(0b0000000_00001_11110_101_01001_0000011)?
         );
 
         // csrrw x1, 1024, x2
@@ -531,7 +534,7 @@ mod tests {
                 rs1: 2,
                 imm: 1024
             }),
-            decode(0b0100000_00000_00010_001_00001_1110011)
+            decode(0b0100000_00000_00010_001_00001_1110011)?
         );
 
         // csrrs x1, 1024, x2
@@ -541,7 +544,7 @@ mod tests {
                 rs1: 2,
                 imm: 1024
             }),
-            decode(0b0100000_00000_00010_010_00001_1110011)
+            decode(0b0100000_00000_00010_010_00001_1110011)?
         );
 
         // csrrc x1, 1024, x2
@@ -551,7 +554,7 @@ mod tests {
                 rs1: 2,
                 imm: 1024
             }),
-            decode(0b0100000_00000_00010_011_00001_1110011)
+            decode(0b0100000_00000_00010_011_00001_1110011)?
         );
 
         // csrrwi x1, 1024, x2
@@ -561,7 +564,7 @@ mod tests {
                 rs1: 2,
                 imm: 1024
             }),
-            decode(0b0100000_00000_00010_101_00001_1110011)
+            decode(0b0100000_00000_00010_101_00001_1110011)?
         );
 
         // csrrsi x1, 1024, x2
@@ -571,7 +574,7 @@ mod tests {
                 rs1: 2,
                 imm: 1024
             }),
-            decode(0b0100000_00000_00010_110_00001_1110011)
+            decode(0b0100000_00000_00010_110_00001_1110011)?
         );
 
         // csrrci x1, 1024, x2
@@ -581,12 +584,13 @@ mod tests {
                 rs1: 2,
                 imm: 1024
             }),
-            decode(0b0100000_00000_00010_111_00001_1110011)
+            decode(0b0100000_00000_00010_111_00001_1110011)?
         );
+        Ok(())
     }
 
     #[test]
-    fn decode_rv32i_s() {
+    fn decode_rv32i_s() -> Result<(), Exception> {
         // sb x1, x2, 2899
         assert_eq!(
             Instruction::Sb(SType {
@@ -594,7 +598,7 @@ mod tests {
                 rs2: 2,
                 imm: 2899
             }),
-            decode(0b1011010_00010_00001_000_10011_0100011)
+            decode(0b1011010_00010_00001_000_10011_0100011)?
         );
 
         // sh x1, x2, 1397
@@ -604,7 +608,7 @@ mod tests {
                 rs2: 2,
                 imm: 1397
             }),
-            decode(0b0101011_00010_00001_001_10101_0100011)
+            decode(0b0101011_00010_00001_001_10101_0100011)?
         );
 
         // sw x1, x2, 1397
@@ -614,12 +618,13 @@ mod tests {
                 rs2: 2,
                 imm: 1397
             }),
-            decode(0b0101011_00010_00001_010_10101_0100011)
+            decode(0b0101011_00010_00001_010_10101_0100011)?
         );
+        Ok(())
     }
 
     #[test]
-    fn decode_rv32i_b() {
+    fn decode_rv32i_b() -> Result<(), Exception> {
         // beq x1, x2, 2048
         assert_eq!(
             Instruction::Beq(BType {
@@ -627,7 +632,7 @@ mod tests {
                 rs2: 2,
                 imm: 2048,
             }),
-            decode(0b0000000_00010_00001_000_00001_1100011)
+            decode(0b0000000_00010_00001_000_00001_1100011)?
         );
 
         // bne x1, x2, 1024
@@ -637,7 +642,7 @@ mod tests {
                 rs2: 2,
                 imm: 1024,
             }),
-            decode(0b0100000_00010_00001_001_00000_1100011)
+            decode(0b0100000_00010_00001_001_00000_1100011)?
         );
 
         // blt x1, x2, 1024
@@ -647,7 +652,7 @@ mod tests {
                 rs2: 2,
                 imm: 1024,
             }),
-            decode(0b0100000_00010_00001_100_00000_1100011)
+            decode(0b0100000_00010_00001_100_00000_1100011)?
         );
 
         // bge x1, x2, 1024
@@ -657,7 +662,7 @@ mod tests {
                 rs2: 2,
                 imm: 1024,
             }),
-            decode(0b0100000_00010_00001_101_00000_1100011)
+            decode(0b0100000_00010_00001_101_00000_1100011)?
         );
 
         // bltu x1, x2, 1024
@@ -667,7 +672,7 @@ mod tests {
                 rs2: 2,
                 imm: 1024,
             }),
-            decode(0b0100000_00010_00001_110_00000_1100011)
+            decode(0b0100000_00010_00001_110_00000_1100011)?
         );
 
         // bgeu x1, x2, 1024
@@ -677,28 +682,30 @@ mod tests {
                 rs2: 2,
                 imm: 1024,
             }),
-            decode(0b0100000_00010_00001_111_00000_1100011)
+            decode(0b0100000_00010_00001_111_00000_1100011)?
         );
+        Ok(())
     }
 
     #[test]
-    fn decode_rv32i_j() {
+    fn decode_rv32i_j() -> Result<(), Exception> {
         // beq x1, 8018
         assert_eq!(
             Instruction::Jal(JType { rd: 1, imm: 8018 }),
-            decode(0b01_1101010011_0_0000001_00001_1101111)
+            decode(0b01_1101010011_0_0000001_00001_1101111)?
         );
+        Ok(())
     }
 
     #[test]
-    fn decode_rv32_u() {
+    fn decode_rv32_u() -> Result<(), Exception> {
         // lui x1, 623706
         assert_eq!(
             Instruction::Lui(UType {
                 rd: 1,
                 imm: 2554699776,
             }),
-            decode(0b10011000010001011010_00001_0110111)
+            decode(0b10011000010001011010_00001_0110111)?
         );
 
         // auipc x1, 103275
@@ -707,7 +714,8 @@ mod tests {
                 rd: 1,
                 imm: 423014400,
             }),
-            decode(0b00011001001101101011_00001_0010111)
+            decode(0b00011001001101101011_00001_0010111)?
         );
+        Ok(())
     }
 }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,0 +1,4 @@
+#[derive(Debug)]
+pub enum Exception {
+    IllegalInstruction,
+}

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,4 +1,5 @@
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Exception {
+    InstructionAddressMisaligned,
     IllegalInstruction,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod decode;
+pub mod exception;
 pub mod memory;
 pub mod processor;

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,3 +1,4 @@
+use crate::exception::Exception;
 use crate::memory::Memory;
 
 use crate::decode::{decode, Instruction, RType};
@@ -31,9 +32,9 @@ impl Processor {
         }
     }
 
-    fn tick(&mut self) {
+    fn tick(&mut self) -> Result<(), Exception> {
         let raw_inst = self.mem.read_inst(self.pc as usize);
-        match decode(raw_inst) {
+        match decode(raw_inst)? {
             Instruction::Add(args) => self.inst_add(&args),
             Instruction::Sub(args) => self.inst_sub(&args),
             Instruction::Sll(args) => self.inst_sll(&args),
@@ -46,6 +47,7 @@ impl Processor {
             Instruction::And(args) => self.inst_and(&args),
             _ => panic!("unimplemented"),
         }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
例外を表現する `Exception` を定義しました．
- 命令がデコードできなかったとき
- `jal` と `jalr` のジャンプ先アドレスが4byte 境界に整列されていないとき
に対応する `Exception` のバリアントを返します．