### PR TITLE
Instruction execution J-Type

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -11,6 +11,8 @@ const FUNCT7_RANGE: Range<usize> = 25..32;
 const IMM_RANGE: Range<usize> = 20..32;
 const UPPER_IMM_RANGE: Range<usize> = 12..32;
 
+/// Enumerates instructions.
+/// Each entry have a struct holding parameters such as register index.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Instruction {
     // R-Type
@@ -69,6 +71,8 @@ pub enum Instruction {
     Auipc(UType),
 }
 
+/// Parameters common to R-Type instructions.
+/// This is the same for structs below.
 #[derive(Debug, PartialEq, Eq)]
 pub struct RType {
     pub rd: usize,
@@ -170,15 +174,15 @@ impl JType {
         let imm = instruction.get_bits(21..31)
             + (instruction.get_bits(20..21) << 10)
             + (instruction.get_bits(12..20) << 11)
-            + (instruction.get_bits(31..32) << 19)
-            << 1;
+            + (instruction.get_bits(31..32) << 19);
         Self {
             rd: instruction.get_bits(RD_RANGE) as usize,
-            imm: imm as u32,
+            imm,
         }
     }
 }
 
+/// Decode an instruction.
 pub fn decode(instruction: u32) -> Result<Instruction, Exception> {
     let decoded = match instruction.get_bits(OPCODE_RANGE) {
         // R-Type
@@ -712,9 +716,9 @@ mod tests {
 
     #[test]
     fn decode_rv32i_j() -> Result<(), Exception> {
-        // jal x1, 529408
+        // jal x1, 264704
         assert_eq!(
-            Instruction::Jal(JType { rd: 1, imm: 529408 }),
+            Instruction::Jal(JType { rd: 1, imm: 264704 }),
             decode(0b01000000000010000001_00001_1101111)?
         );
         Ok(())

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -4,8 +4,10 @@ pub trait Memory {
 
     /// Read byte located at *addr*
     fn read_byte(&self, addr: usize) -> u8;
+
     /// Read half word located at *addr*
     fn read_halfword(&self, addr: usize) -> u16;
+
     /// Read word located at *addr*
     fn read_word(&self, addr: usize) -> u32;
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -126,7 +126,7 @@ impl Processor {
 
         // If no jump occured, increment pc.
         if !self.has_jumped {
-            self.pc +=  4;
+            self.pc += 4;
         }
         self.has_jumped = false;
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,4 +1,4 @@
-use crate::decode::{decode, BType, IType, Instruction, RType, UType};
+use crate::decode::{decode, BType, IType, Instruction, JType, RType, UType};
 use crate::exception::Exception;
 use crate::memory::Memory;
 
@@ -50,6 +50,7 @@ impl Processor {
         }
     }
 
+    /// Read the register value at index `idx`.
     fn read_reg(&self, idx: usize) -> u32 {
         if idx == 0 {
             0
@@ -58,12 +59,14 @@ impl Processor {
         }
     }
 
+    /// Write value to the register at index `idx`.
     fn write_reg(&mut self, idx: usize, val: u32) {
         if idx != 0 {
             self.regs[idx] = val;
         }
     }
 
+    /// Read an instruction from current program counter and execute it.
     pub fn tick(&mut self) -> Result<(), Exception> {
         if self.pc + 4 > self.mem.len() as u32 {
             return Err(Exception::InstructionAccessFault);
@@ -72,6 +75,7 @@ impl Processor {
         let mut skip_inc = false;
         let raw_inst = self.mem.read_inst(self.pc as usize);
         match decode(raw_inst)? {
+            // R-Type
             Instruction::Add(args) => self.inst_add(&args),
             Instruction::Sub(args) => self.inst_sub(&args),
             Instruction::Sll(args) => self.inst_sll(&args),
@@ -83,6 +87,7 @@ impl Processor {
             Instruction::Or(args) => self.inst_or(&args),
             Instruction::And(args) => self.inst_and(&args),
 
+            // I-Type
             Instruction::Jalr(args) => {
                 self.inst_jalr(&args);
                 skip_inc = true;
@@ -114,6 +119,9 @@ impl Processor {
             Instruction::Auipc(args) => self.inst_auipc(&args),
             Instruction::Lui(args) => self.inst_lui(&args),
 
+            // J-Type
+            Instruction::Jal(args) => self.inst_jal(&args)?,
+
             _ => panic!("unimplemented"),
         }
 
@@ -130,6 +138,15 @@ impl Processor {
             (val as u32) | 0xfffff000
         } else {
             val as u32
+        }
+    }
+
+    // Sign extend given integer with 20bit.
+    const fn sign_extend_20bit(value: u32) -> i32 {
+        if value & 0xfff80000 != 0 {
+            (value | 0xfff00000) as i32
+        } else {
+            value as i32
         }
     }
 
@@ -378,6 +395,17 @@ impl Processor {
     fn inst_lui(&mut self, args: &UType) {
         let imm = args.imm << 12;
         self.write_reg(args.rd, imm);
+    }
+
+    fn inst_jal(&mut self, args: &JType) -> Result<(), Exception> {
+        self.write_reg(args.rd, self.pc + 4);
+        let offset = Self::sign_extend_20bit(args.imm);
+        let new_pc = (self.pc as i32).wrapping_add(offset) as u32;
+        if new_pc % 4 != 0 {
+            return Err(Exception::InstructionAddressMisaligned);
+        }
+        self.set_pc(new_pc);
+        Ok(())
     }
 }
 
@@ -1034,9 +1062,45 @@ mod tests {
         let mut proc = Processor::new(memory);
         proc.write_reg(1, 0x0);
         // If pc is 0, cannot detect not adding `imm` to current pc.
-        proc.set_pc(4);
+        proc.set_pc(0x4);
         proc.inst_auipc(&args);
         assert_eq!(proc.read_reg(args.rd), 0xfffff004);
         assert_eq!(proc.pc, 0xfffff004);
+    }
+
+    #[test]
+    fn calc_rv32i_j_jal() -> Result<(), Exception> {
+        let memory: Box<dyn Memory> = Box::new(EmptyMemory);
+        let args = JType { rd: 1, imm: 0x80 };
+
+        let mut proc = Processor::new(memory);
+        proc.write_reg(1, 0x0);
+        proc.set_pc(0x4);
+        proc.inst_jal(&args)?;
+        assert_eq!(proc.read_reg(args.rd), 0x8);
+        assert_eq!(proc.pc, 0x84);
+
+        let args = JType {
+            rd: 1,
+            imm: 0xfffffffc, // -4
+        };
+        proc.inst_jal(&args)?;
+        assert_eq!(proc.read_reg(args.rd), 0x88);
+        assert_eq!(proc.pc, 0x80);
+        Ok(())
+    }
+
+    #[test]
+    fn calc_rv32i_j_jal_invalid_address() -> Result<(), Exception> {
+        let memory: Box<dyn Memory> = Box::new(EmptyMemory);
+        let args = JType { rd: 1, imm: 0x82 };
+
+        let mut proc = Processor::new(memory);
+        proc.write_reg(1, 0x0);
+        assert_eq!(
+            proc.inst_jal(&args),
+            Err(Exception::InstructionAddressMisaligned)
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
closes: #38 
J-Type 命令の実行を実装しました．
ジャンプ後に `pc` をインクリメントしない部分ですが，すべて
```rust
Instruction::Jalr(args) => {
    self.inst_jalr(&args);
    self.skip_inc = true;
}
```

としていると見づらくなる気がしたので
* `has_jumped: bool` というメンバ変数を用意
* ジャンプしたらこの変数を `true` にする
* `has_jumped` が `false` なら `pc` をインクリメントする

ようにしました．他の案があれば教えてください．